### PR TITLE
Port to 1.16.1 and optimise code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,19 +13,20 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.15.2-1.0.2'
+version = '1.16.1-1.0.3'
 group = 'dk.zlepper.itlt' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'itlt'
 
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 
+println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 minecraft {
     // The mappings can be changed at any time, and must be in the following format.
     // snapshot_YYYYMMDD   Snapshot are built nightly.
     // stable_#            Stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'snapshot', version: '20200225-1.15.1'
+    mappings channel: 'snapshot', version: '20200707-1.16.1'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
     
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -89,7 +90,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.15.2-31.1.35'
+    minecraft 'net.minecraftforge:forge:1.16.1-32.0.71'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/src/main/java/dk/zlepper/itlt/Config.java
+++ b/src/main/java/dk/zlepper/itlt/Config.java
@@ -10,7 +10,7 @@ import net.minecraftforge.fml.config.ModConfig;
 import java.io.File;
 import java.nio.file.Path;
 
-public class Config {
+public final class Config {
 
     public static final String CATEGORY_BIT_DETECTION = "BitDetection";
     public static final String CATEGORY_DISPLAY = "Display";
@@ -38,7 +38,7 @@ public class Config {
         CLIENT_BUILDER.comment("Bit detection").push(CATEGORY_BIT_DETECTION);
 
         BIT_DETECTION_SHOULD_YELL_AT_32_BIT_USERS = CLIENT_BUILDER.comment("Set to true to make itlt yell at people attempting to use 32x java for the modpack.")
-                .define("ShouldYellAt32BitUsers", false);
+                .define("ShouldYellAt32BitUsers", true);
         BIT_DETECTION_MESSAGE = CLIENT_BUILDER.comment("If ShouldYellAt32BitUsers is set to true, this is the message that will be displayed to the user.")
                 .define("Message", "You are using a 32 bit version of java. This is not recommended with this modpack.");
 
@@ -77,7 +77,7 @@ public class Config {
     }
 
 
-    public static void loadConfig(ForgeConfigSpec spec, Path path) {
+    public static void loadConfig(ForgeConfigSpec spec, final Path path) {
 
         final CommentedFileConfig configData = CommentedFileConfig.builder(path)
                 .sync()

--- a/src/main/java/dk/zlepper/itlt/Itlt.java
+++ b/src/main/java/dk/zlepper/itlt/Itlt.java
@@ -20,8 +20,8 @@ import net.minecraftforge.fml.loading.FMLPaths;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.lwjgl.glfw.GLFW;
-import org.lwjgl.glfw.GLFWImage;
+//import org.lwjgl.glfw.GLFW;
+//import org.lwjgl.glfw.GLFWImage;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -31,10 +31,10 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 @Mod("itlt")
-public class Itlt {
+public final class Itlt {
 
     private static final Logger LOGGER = LogManager.getLogger();
-    public static CommonProxy proxy = DistExecutor.runForDist(() -> () -> new ClientProxy(), () -> () -> new ServerProxy());
+    public static CommonProxy proxy = DistExecutor.runForDist(() -> ClientProxy::new, () -> ServerProxy::new);
 
     private String windowDisplayTitle;
 
@@ -52,13 +52,15 @@ public class Itlt {
             return;
         }
 
-        boolean shouldYell = Config.BIT_DETECTION_SHOULD_YELL_AT_32_BIT_USERS.get();
-        String yelling = shouldYell ? "We are yelling at people" : "We are NOT yelling at people";
+        final boolean shouldYell = Config.BIT_DETECTION_SHOULD_YELL_AT_32_BIT_USERS.get();
+        final String yelling = shouldYell ? "We are yelling at people" : "We are NOT yelling at people";
         LOGGER.info(yelling);
 
+        final Minecraft mcInstance = Minecraft.getInstance();
+
         if (shouldYell) {
-            if (!Minecraft.getInstance().isJava64bit()) {
-                ShouterThread st = new ShouterThread(Config.BIT_DETECTION_MESSAGE.get());
+            if (!mcInstance.isJava64bit()) {
+                final ShouterThread st = new ShouterThread(Config.BIT_DETECTION_MESSAGE.get());
                 st.start();
             }
         }
@@ -66,14 +68,14 @@ public class Itlt {
         windowDisplayTitle = Config.DISPLAY_WINDOW_DISPLAY_TITLE.get();
 
         //GLFW.glfwSetWindowTitle(Minecraft.getInstance().getMainWindow().getHandle(), windowDisplayTitle);
-        Minecraft.getInstance().getMainWindow().func_230148_b_(windowDisplayTitle);
+        mcInstance.getMainWindow().func_230148_b_(windowDisplayTitle);
         //LOGGER.info("Set window title");
 
         if (Config.DISPLAY_LOAD_CUSTOM_ICON.get()) {
             File di = Paths.get(FMLPaths.CONFIGDIR.get().toAbsolutePath().toString(), "itlt").toFile();
             LOGGER.info(di);
             if (di.exists()) {
-                File icon = Paths.get(di.getAbsolutePath(), "icon.png").toFile();
+                final File icon = Paths.get(di.getAbsolutePath(), "icon.png").toFile();
                 LOGGER.info(icon.exists() ? "Custom modpack icon found" : "Custom modpack icon NOT found.");
                 if (icon.exists() && !icon.isDirectory()) {
                     SetWindowIcon(icon);
@@ -87,9 +89,9 @@ public class Itlt {
         }
 
         if (Config.DISPLAY_USE_TECHNIC_ICON.get()) {
-            Path assets = getAssetDir();
+            final Path assets = getAssetDir();
 
-            File icon = Paths.get(assets.toAbsolutePath().toString(), "icon.png").toFile();
+            final File icon = Paths.get(assets.toAbsolutePath().toString(), "icon.png").toFile();
             LOGGER.info(icon.exists() ? "Technic icon found" : "Technic icon NOT found. ");
             if (icon.exists() && !icon.isDirectory()) {
                 SetWindowIcon(icon);
@@ -99,7 +101,7 @@ public class Itlt {
         if (Config.DISPLAY_USE_TECHNIC_DISPLAY_NAME.get()) {
             Path assets = getAssetDir();
 
-            File cacheFile = Paths.get(assets.toAbsolutePath().toString(), "cache.json").toFile();
+            final File cacheFile = Paths.get(assets.toAbsolutePath().toString(), "cache.json").toFile();
             LOGGER.info(cacheFile.exists() ? "Cache file found" : "Cache file not found.");
             if (cacheFile.exists() && !cacheFile.isDirectory()) {
                 String json = null;
@@ -110,7 +112,7 @@ public class Itlt {
                     LOGGER.error(e.toString());
                 }
                 if (json != null) {
-                    Map cacheContents = new Gson().fromJson(json, Map.class);
+                    final Map cacheContents = new Gson().fromJson(json, Map.class);
                     LOGGER.info(cacheContents.size());
                     if (cacheContents.containsKey("displayName")) {
                         LOGGER.info(cacheContents.get("displayName").toString());
@@ -121,8 +123,8 @@ public class Itlt {
         }
 
         if (Config.SERVER_ADD_DEDICATED_SERVER.get()) {
-            ServerList serverList = new ServerList(Minecraft.getInstance());
-            int c = serverList.countServers();
+            ServerList serverList = new ServerList(mcInstance);
+            final int c = serverList.countServers();
             boolean foundServer = false;
             for (int i = 0; i < c; i++) {
                 ServerData data = serverList.getServerData(i);
@@ -133,9 +135,7 @@ public class Itlt {
                 }
             }
             if (!foundServer) {
-                // I have no clue what the last boolean is for.
-                // Possibly decides if it's a lan server, or an actual multiplayer server.
-                // Settings it to false should make it a multiplayer server
+                // The last boolean determines if it is a lan server (true), or an actual multiplayer server (false)
                 ServerData data = new ServerData(Config.SERVER_SERVER_NAME.get(), Config.SERVER_SERVER_IP.get(), false);
                 serverList.addServerData(data);
                 serverList.saveServerList();
@@ -158,15 +158,15 @@ public class Itlt {
 
     private Path getAssetDir() {
         // Get the current Working directory
-        Path currentRelativePath = Paths.get("").toAbsolutePath();
-        String slugname = currentRelativePath.getFileName().toString();
+        final Path currentRelativePath = Paths.get("").toAbsolutePath();
+        final String slugname = currentRelativePath.getFileName().toString();
 
-        Path directParent = currentRelativePath.getParent();
+        final Path directParent = currentRelativePath.getParent();
         if (directParent == null) {
             return currentRelativePath;
         }
         // Should be the .technic directory
-        Path technic = directParent.getParent();
+        final Path technic = directParent.getParent();
         if (technic == null) {
             return currentRelativePath;
         }

--- a/src/main/java/dk/zlepper/itlt/about/mod.java
+++ b/src/main/java/dk/zlepper/itlt/about/mod.java
@@ -1,7 +1,8 @@
 package dk.zlepper.itlt.about;
 
 public final class mod {
-    public static final String ID = "itlt";
-    public static final String NAME = "It's the little things";
-    public static final String VERSION = "1.0.0";
+    public static final String
+            ID = "itlt",
+            NAME = "It's the little things",
+            VERSION = "1.0.3";
 }

--- a/src/main/java/dk/zlepper/itlt/helpers/IconLoader.java
+++ b/src/main/java/dk/zlepper/itlt/helpers/IconLoader.java
@@ -56,7 +56,7 @@ public class IconLoader
             e.printStackTrace();
         }
         ByteBuffer[] buffers = null;
-        String OS = System.getProperty("os.name").toUpperCase();
+        final String OS = System.getProperty("os.name").toUpperCase();
         if(OS.contains("WIN"))
         {
             buffers = new ByteBuffer[2];

--- a/src/main/java/dk/zlepper/itlt/threads/ShouterThread.java
+++ b/src/main/java/dk/zlepper/itlt/threads/ShouterThread.java
@@ -5,11 +5,11 @@ import dk.zlepper.itlt.proxies.ClientProxy;
 
 import javax.swing.*;
 
-public class ShouterThread extends Thread {
+public final class ShouterThread extends Thread {
 
     private String message;
 
-    public ShouterThread(String message) {
+    public ShouterThread(final String message) {
         this.message = message;
     }
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -33,7 +33,7 @@ A mod for improving the little things, the final touches
     # Does this dependency have to exist - if not, ordering below must be specified
     mandatory=true #mandatory
     # The version range of the dependency
-    versionRange="[31,)" #mandatory
+    versionRange="[32,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER
@@ -42,6 +42,6 @@ A mod for improving the little things, the final touches
 [[dependencies.itlt]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.15.2,]"
+    versionRange="[1.16.1,]"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
- Ported to Forge 32.0.71 (for MC 1.16.1)
- A couple of lambdas have been changed to references for a tiny performance increase and clearer code
- Variables, classes and arguments are now marked as final/immutable where possible
- We now get the instance of Minecraft once and reuse that reference where possible to save a tiny bit more memory rather than getting and using new references of the instance every time
- ShouldYellAt32BitUsers is now true by default as 64bit Java is beneficial even for Vanilla users due to increased performance and increased default and max render distances.

From Paint_Ninja on CurseForge :)