### PR TITLE
Fix server compatibility indicator Minecraft Forge 1.16.4

### DIFF
--- a/src/main/java/dk/zlepper/itlt/Itlt.java
+++ b/src/main/java/dk/zlepper/itlt/Itlt.java
@@ -11,13 +11,16 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.multiplayer.ServerList;
 import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.ExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLPaths;
+import net.minecraftforge.fml.network.FMLNetworkConstants;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 //import org.lwjgl.glfw.GLFW;
@@ -40,6 +43,7 @@ public final class Itlt {
         System.setProperty("java.awt.headless", "false");
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientInit);
 
+        ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (a, b) -> true));
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, Config.CLIENT_CONFIG);
         Config.loadConfig(Config.CLIENT_CONFIG, FMLPaths.CONFIGDIR.get().resolve("itlt-client.toml"));
     }


### PR DESCRIPTION
Fixes this with the mod installed only on the client

![image](https://user-images.githubusercontent.com/6520738/104641283-8d7fec00-5677-11eb-85c1-dc5c2df55997.png)
